### PR TITLE
[#56] News 조회시 날짜 파라미터 스펙 변경

### DIFF
--- a/src/main/java/com/snack/news/controller/NewsController.java
+++ b/src/main/java/com/snack/news/controller/NewsController.java
@@ -3,7 +3,9 @@ package com.snack.news.controller;
 import com.snack.news.domain.News;
 import com.snack.news.dto.NewsDto;
 import com.snack.news.dto.WrappedResponse;
+import com.snack.news.exception.NewsBadRequestException;
 import com.snack.news.service.NewsService;
+import com.snack.news.util.WeekUtil;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +26,11 @@ public class NewsController {
 
 	@GetMapping
 	public ResponseEntity<List<News>> getNewsListRequestBody(@ModelAttribute NewsDto newsDto) {
+		boolean isValidDate = WeekUtil.isBothDatesInOneWeekWithSameMonth(newsDto.getStartDateTime(), newsDto.getEndDateTime());
+		if (!isValidDate) {
+			throw new NewsBadRequestException();
+		}
+
 		List<News> result = newsService.getNewsList(newsDto);
 		if (result.isEmpty()) {
 			return ResponseEntity.noContent().build();

--- a/src/main/java/com/snack/news/dto/NewsDto.java
+++ b/src/main/java/com/snack/news/dto/NewsDto.java
@@ -1,7 +1,6 @@
 package com.snack.news.dto;
 
 import com.snack.news.domain.*;
-import com.snack.news.util.WeekUtil;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -29,9 +28,9 @@ public class NewsDto {
 	private List<Long> topicIds;
 	private List<Long> tagIds;
 	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-	private LocalDateTime startDateTime = WeekUtil.getFirstDayOfWeek(LocalDateTime.now());
+	private LocalDateTime startDateTime;
 	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-	private LocalDateTime endDateTime = WeekUtil.getLastDayOfWeek(LocalDateTime.now());
+	private LocalDateTime endDateTime;
 
 	public News toEntity(Category category, List<Topic> topics, List<Tag> tags) {
 		return News.builder()

--- a/src/main/java/com/snack/news/util/WeekUtil.java
+++ b/src/main/java/com/snack/news/util/WeekUtil.java
@@ -1,14 +1,29 @@
 package com.snack.news.util;
 
+import com.snack.news.exception.NewsBadRequestException;
+
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class WeekUtil {
-	public static LocalDateTime getFirstDayOfWeek(LocalDateTime date) {
-		return date.minusDays(date.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue()).withHour(0).withMinute(0).withSecond(0);
+	public static boolean isBothDatesInOneWeekWithSameMonth(LocalDateTime start, LocalDateTime end) {
+		if (Objects.isNull(start) || Objects.isNull(end)) {
+			throw new NewsBadRequestException();
+		}
+
+		if (!start.getDayOfWeek().equals(DayOfWeek.MONDAY)) {
+			return false;
+		}
+
+		return isBothDatesInOneWeek(start, end) && isBothDatesInSameMonth(start, end);
 	}
 
-	public static LocalDateTime getLastDayOfWeek(LocalDateTime date) {
-		return date.plusDays(DayOfWeek.SUNDAY.getValue() - date.getDayOfWeek().getValue()).withHour(11).withMinute(59).withSecond(59);
+	private static boolean isBothDatesInOneWeek(LocalDateTime start, LocalDateTime end) {
+		return end.minusWeeks(1L).isBefore(start);
+	}
+
+	private static boolean isBothDatesInSameMonth(LocalDateTime start, LocalDateTime end) {
+		return end.getMonth() == start.getMonth();
 	}
 }

--- a/src/test/java/com/snack/news/util/WeekUtilTest.java
+++ b/src/test/java/com/snack/news/util/WeekUtilTest.java
@@ -1,40 +1,62 @@
 package com.snack.news.util;
 
+import com.snack.news.exception.NewsBadRequestException;
 import com.snack.news.fixture.NewsTestcase;
 import org.junit.Test;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
+import static org.hamcrest.Matchers.*;
 
 public class WeekUtilTest extends NewsTestcase {
 
-	private static final LocalDateTime dateOf20190729Monday0000 = LocalDateTime.of(2019, 7, 29, 0, 0, 0);
-	private static final LocalDateTime dateOf20190804Sunday1159 = LocalDateTime.of(2019, 8, 4, 11, 59, 59);
-
+	@Test(expected = NewsBadRequestException.class)
+	public void 날짜_값이_null이면_예외가_발생한다() {
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(null, null), is(any(Boolean.class)));
+	}
 	@Test
-	public void 월요일에_대한_한주의_시작날과_마지막날을_정상적으로_반환한다() {
-		LocalDateTime someMonday = dateOf20190729Monday0000;
-		assertThat(someMonday.getDayOfWeek(), equalTo(DayOfWeek.MONDAY));
-		assertThat(WeekUtil.getFirstDayOfWeek(someMonday), equalTo(dateOf20190729Monday0000));
-		assertThat(WeekUtil.getLastDayOfWeek(someMonday), equalTo(dateOf20190804Sunday1159));
+	public void 시작일이_월요일이_아니면_거짓을_반환한다() {
+		final LocalDateTime start = LocalDateTime.of(2019, 8, 13, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2019, 8, 14, 0, 0);
+
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(false));
 	}
 
 	@Test
-	public void 화요일과_금요일_사이에_대한_한주의_시작날과_마지막날을_정상적으로_반환한다() {
-		LocalDateTime someday = LocalDateTime.of(2019, 8, 1, 0, 0, 0);
-		assertThat(WeekUtil.getFirstDayOfWeek(someday), equalTo(dateOf20190729Monday0000));
-		assertThat(WeekUtil.getLastDayOfWeek(someday), equalTo(dateOf20190804Sunday1159));
+	public void 두_날짜의_차이가_7일을_초과하면_거짓을_반환한다() {
+		final LocalDateTime start = LocalDateTime.of(2019, 8, 12, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2019, 8, 15, 0, 0);
+
+		assertThat(start.getDayOfWeek().equals(DayOfWeek.MONDAY), is(true));
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(true));
 	}
 
 	@Test
-	public void 일요일에_대한_한주의_시작날과_마지막날을_정상적으로_반환한다() {
-		LocalDateTime someSunday = dateOf20190804Sunday1159;
-		assertThat(someSunday.getDayOfWeek(), equalTo(DayOfWeek.SUNDAY));
-		assertThat(WeekUtil.getFirstDayOfWeek(someSunday), equalTo(dateOf20190729Monday0000));
-		assertThat(WeekUtil.getLastDayOfWeek(someSunday), equalTo(dateOf20190804Sunday1159));
+	public void 두_날짜의_차이가_7일_미만이고_같은_달이면_참을_반환한다() {
+		final LocalDateTime start = LocalDateTime.of(2019, 8, 12, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2019, 8, 14, 0, 0);
+
+		assertThat(start.getDayOfWeek().equals(DayOfWeek.MONDAY), is(true));
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(true));
+	}
+
+	@Test
+	public void 두_날짜의_차이가_정확히_7일이고_같은_달이면_참을_반환한다() {
+		final LocalDateTime start = LocalDateTime.of(2019, 8, 12, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2019, 8, 18, 0, 0);
+
+		assertThat(start.getDayOfWeek().equals(DayOfWeek.MONDAY), is(true));
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(true));
+	}
+
+
+	@Test
+	public void 두_날짜의_치이가_7일_이하지만_다른_달이면_거짓을_반환한다() {
+		final LocalDateTime start = LocalDateTime.of(2019, 8, 26, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2019, 9, 1, 0, 0);
+
+		assertThat(start.getDayOfWeek().equals(DayOfWeek.MONDAY), is(true));
+		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(false));
 	}
 }

--- a/src/test/java/com/snack/news/util/WeekUtilTest.java
+++ b/src/test/java/com/snack/news/util/WeekUtilTest.java
@@ -49,6 +49,7 @@ public class WeekUtilTest extends NewsTestcase {
 
 		assertThat(start.getDayOfWeek().equals(DayOfWeek.MONDAY), is(true));
 		assertThat(WeekUtil.isBothDatesInOneWeekWithSameMonth(start, end), is(true));
+	}
 
 	@Test
 	public void 두_날짜의_치이가_7일_이하지만_다른_달이면_거짓을_반환한다() {


### PR DESCRIPTION
- 디폴트 값 제거하고 필수 파라미터로 지정
- 날짜 값을 따로 검증하여 조건에 맞지 않으면 예외(월요일 시작, 1주 이내, 같은 달)