### PR TITLE
travisbuddy 추가

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,4 @@ deploy:
 
 notifications:
   slack: opensourcekr:3wXZfw1QFGKrbPrNR99ZLR10
+  webhooks: https://travisbuddy.herokuapp.com/


### PR DESCRIPTION
### 이런게 변경되었어요. 💍

travis 빌드시 에러가 나면 아래와 같이 PR comment로 남겨주는 설정.
https://github.com/snack-news/Snack-FE/pull/228#issuecomment-533484498


### Reference

아래 코드를 기반으로 heroku에 서버를 켰으며
https://github.com/bluzi/travis-buddy

서버 주소: https://travisbuddy.herokuapp.com/

travis에 설정된 notifications 설정에 따라 위 주소로 travis 실행 로그 정보가 전달됩니다.
그 로그정보를 받고 가공하여 github API를 통해 PR comment를 남기게 됩니다.

github API 를 쓸때 사용하는 토큰정보는 코드상에는 없으며, heroku 에 설정해둔 환경설정값을 사용합니다.