### PR TITLE
Sort library의 Deprecated method 변경

### DIFF
--- a/src/main/java/com/snack/news/service/AdminService.java
+++ b/src/main/java/com/snack/news/service/AdminService.java
@@ -20,7 +20,7 @@ import java.util.List;
 @AllArgsConstructor
 @Service
 public class AdminService {
-	private final static Sort SORT_BY_ID = new Sort(Sort.Direction.DESC, "id");
+	private final static Sort SORT_BY_ID = Sort.by(Sort.Direction.DESC, "id");
 
 	private final NewsRepository newsRepository;
 	private final CategoryService categoryService;

--- a/src/test/java/com/snack/news/repository/NewsRepositoryTest.java
+++ b/src/test/java/com/snack/news/repository/NewsRepositoryTest.java
@@ -220,7 +220,7 @@ public class NewsRepositoryTest extends NewsFixture {
 		long lastNewsId4 = expectedListFistNewsPage.get(3).getId();
 		long lastNewsId5 = expectedListFistNewsPage.get(4).getId();
 
-		Pageable pageableDesc = PageRequest.of(0, pageSize, new Sort(Sort.Direction.DESC, "id"));
+		Pageable pageableDesc = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 		List<News> result = newsRepository.findAll(pageableDesc).getContent();
 
 		assertThat(result.stream().map(News::getId).collect(toList()),


### PR DESCRIPTION
### 이런게 변경되었어요. 💍
- Sort library의 Deprecated method 변경

### Reference
- https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Sort.html