### PR TITLE
Downgrade SpringBoot Version 2.2.1 -> 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.2.1.RELEASE'
+        springBootVersion = '2.2.0.RELEASE'
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
### 이런게 변경되었어요. 💍
- 2.2.1이 호환성이슈가 너무 많아서 2.2.0으로 낮춥니다.

### Reference
- 