### PR TITLE
hotfix: JpaRepository 메서드 이름 쿼리 수정

### DIFF
--- a/src/main/java/com/snack/news/repository/TopicRepository.java
+++ b/src/main/java/com/snack/news/repository/TopicRepository.java
@@ -11,7 +11,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
 	List<Topic> findByIdIn(List<Long> ids);
 
-	boolean existsNotByName(String name);
+	boolean existsByName(String name);
 
 	Topic findByName(String name);
 }

--- a/src/main/java/com/snack/news/service/TopicService.java
+++ b/src/main/java/com/snack/news/service/TopicService.java
@@ -61,7 +61,7 @@ public class TopicService {
 	}
 
 	private Topic createTopicIfAbsent(String topicName) {
-		if (topicRepository.existsNotByName(topicName)) {
+		if (!topicRepository.existsByName(topicName)) {
 			TopicDto topic = TopicDto.builder().name(topicName).type(TopicType.CORP).build();
 			return createTopic(topic);
 		}

--- a/src/test/java/com/snack/news/service/TopicServiceTest.java
+++ b/src/test/java/com/snack/news/service/TopicServiceTest.java
@@ -147,7 +147,7 @@ public class TopicServiceTest extends TopicFixture {
 		Topic topicKakao = TopicDto.builder().name(topicNameKakao).type(TopicType.CORP).build().getTopicNewEntity();
 		final List<Topic> dummyResult = Collections.singletonList(topicKakao);
 
-		when(topicRepository.existsNotByName(anyString())).thenReturn(false);
+		when(topicRepository.existsByName(anyString())).thenReturn(true);
 		when(topicRepository.findByName(anyString())).thenReturn(topicKakao);
 
 		List<Topic> realResult = topicService.getTopicList(validTopicNames);
@@ -164,7 +164,7 @@ public class TopicServiceTest extends TopicFixture {
 
 		final List<Topic> dummyResult = Collections.singletonList(newTopic);
 
-		when(topicRepository.existsNotByName(anyString())).thenReturn(true);
+		when(topicRepository.existsByName(anyString())).thenReturn(false);
 
 		List<Topic> realResult = topicService.getTopicList(validTopicNames);
 		verify(topicRepository, times(1)).save(newTopic);


### PR DESCRIPTION
### 이런게 변경되었어요. 💍
- JpaRepository 메서드 이름 쿼리 수정: not이 적용되지 않음