### PR TITLE
버그 수정: 토픽 중복체크 JPA method query 수정

### DIFF
--- a/src/main/java/com/snack/news/repository/TopicRepository.java
+++ b/src/main/java/com/snack/news/repository/TopicRepository.java
@@ -11,7 +11,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
 	List<Topic> findByIdIn(List<Long> ids);
 
-	boolean existsByNameNot(String name);
+	boolean existsByName(String name);
 
 	Topic findByName(String name);
 }

--- a/src/main/java/com/snack/news/service/TopicService.java
+++ b/src/main/java/com/snack/news/service/TopicService.java
@@ -61,11 +61,12 @@ public class TopicService {
 	}
 
 	private Topic createTopicIfAbsent(String topicName) {
-		if (topicRepository.existsByNameNot(topicName)) {
-			TopicDto topic = TopicDto.builder().name(topicName).type(TopicType.CORP).build();
-			return createTopic(topic);
+		if (topicRepository.existsByName(topicName)) {
+			return topicRepository.findByName(topicName);
 		}
-		return topicRepository.findByName(topicName);
+
+		TopicDto topic = TopicDto.builder().name(topicName).type(TopicType.CORP).build();
+		return createTopic(topic);
 	}
 
 	@Transactional

--- a/src/test/java/com/snack/news/service/TopicServiceTest.java
+++ b/src/test/java/com/snack/news/service/TopicServiceTest.java
@@ -155,7 +155,7 @@ class TopicServiceTest extends TopicFixture {
 		Topic topicKakao = TopicDto.builder().name(topicNameKakao).type(TopicType.CORP).build().getTopicNewEntity();
 		final List<Topic> dummyResult = Collections.singletonList(topicKakao);
 
-		when(topicRepository.existsByNameNot(anyString())).thenReturn(false);
+		when(topicRepository.existsByName(anyString())).thenReturn(true);
 		when(topicRepository.findByName(anyString())).thenReturn(topicKakao);
 
 		List<Topic> realResult = topicService.getTopicList(validTopicNames);
@@ -173,7 +173,7 @@ class TopicServiceTest extends TopicFixture {
 
 		final List<Topic> dummyResult = Collections.singletonList(newTopic);
 
-		when(topicRepository.existsByNameNot(anyString())).thenReturn(true);
+		when(topicRepository.existsByName(anyString())).thenReturn(false);
 
 		List<Topic> realResult = topicService.getTopicList(validTopicNames);
 		verify(topicRepository, times(1)).save(newTopic);


### PR DESCRIPTION
### 이런게 변경되었어요. 💍
- #143 에서 수정했던`existsByNameNot` method qurey(부정)가 동작하지 않음을 확인
